### PR TITLE
fixed readme file for the updated fastapi command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ poetry run pytest -vv -s tests
 ## Start the FastAPI web server
 
 ```
-poetry run gunicorn main:app -b 0.0.0.0:6565 -k uvicorn.workers.UvicornWorker --reload
+poetry run gunicorn thor.main:app -b 0.0.0.0:6565 -k uvicorn.workers.UvicornWorker --reload
 ```


### PR DESCRIPTION
Fixed the Readme file so that it contains the correct path to start the FastAPI web server. 
This fixed command should make it easier for us to navigate to the server as the last command was not working at times.  